### PR TITLE
価格部分の読み取り精度を上げる

### DIFF
--- a/household_accounts/ocr.py
+++ b/household_accounts/ocr.py
@@ -94,6 +94,7 @@ class OcrReceipt:
     def modify_price(self, price):
         for before, after in zip(self.conversion_num_before, self.conversion_num_after):
             price = [re.sub(before, after, p) for p in price]
+        price = [re.sub(r'([A-Z]|[a-z])', r'', p) for p in price]
         return price
 
 

--- a/household_accounts/ocr.py
+++ b/household_accounts/ocr.py
@@ -57,7 +57,7 @@ class OcrReceipt:
 
     def get_payment_date(self, content):
         payment_date = [re.search(self.date_regex, s).group() for s in content if re.search(self.date_regex+r'(\(|日)', s)]
-        payment_date = payment_date[0] if payment_date != [] else '0000/00/00'
+        payment_date = payment_date[0] if payment_date != [] else '2000/01/01'
         payment_date = re.sub(r'(年|月)', r'/', payment_date)
         payment_date = datetime.strptime(payment_date, '%Y/%m/%d').strftime('%Y/%m/%d')
         return payment_date

--- a/household_accounts/ocr.py
+++ b/household_accounts/ocr.py
@@ -17,6 +17,9 @@ class OcrReceipt:
     top_num_regex = r'^[0-9]*'
     tax_ex_regex = r'外税'
     tax_in_regex = r'(内税|内消費税等)'
+    conversion_num_before = ['O', 'U', 'b', 'Z', '<', 'i']  # アルファベットとして認識されている価格を変換するため
+    conversion_num_after = ['0', '0', '6', '2', '2', '1']
+
 
     def __init__(self, input_file):
         self.input_file = input_file
@@ -26,6 +29,7 @@ class OcrReceipt:
         main_contents = self.get_main_contents(receipt_content)
         self.reduced_tax_rate_flg = self.get_reduced_tax_rate_flg(main_contents)
         self.item, self.price = self.get_item_and_price(main_contents)
+        self.price = self.modify_price(self.price)
 
 
     def ocr(self, input_file):
@@ -85,6 +89,12 @@ class OcrReceipt:
         item = [re.sub(r'\\', r'', s) for s in item]
         price = [re.search(self.price_regex, s).group() for s in item_and_price]
         return item, price
+    
+
+    def modify_price(self, price):
+        for before, after in zip(self.conversion_num_before, self.conversion_num_after):
+            price = [re.sub(before, after, p) for p in price]
+        return price
 
 
 def summing_up_ocr_results(ocr):

--- a/household_accounts/ocr.py
+++ b/household_accounts/ocr.py
@@ -13,7 +13,7 @@ class OcrReceipt:
     total_regex = r'(合計|小計|ノヽ言十|消費税).*[0-9]*'
     item_price_regex = r'([0-9]|\*|＊|※|[a-z]|[A-Z])\Z'  # 末尾が数字か軽減税率の記号かアルファベット（数字が読み取れていない場合用）
     price_regex = r'([0-9]|[a-z]|[A-Z])*\Z'  # アルファベットは数値が誤って変換されていることがあるため
-    reduced_tax_regex = r'(\*|＊|※)'
+    reduced_tax_regex = r'(\*|＊|※|W|w)'
     top_num_regex = r'^[0-9]*'
     tax_ex_regex = r'外税'
     tax_in_regex = r'(内税|内消費税等)'


### PR DESCRIPTION
精度を上げるためにやってみる
- 誤って誤認識されやすい物を登録して変換を入れる（数字の6をbと誤認識するなど）
- 元が何の数字か不明なアルファベットは消す
- 価格が高すぎる行は消す（No.123456みたいな行、品目行でない）
