### PR TITLE
過去の修正内容を元にしてあらかじめ修正するようにする（品目名）

### DIFF
--- a/household_accounts/gui_each_receipt.py
+++ b/household_accounts/gui_each_receipt.py
@@ -9,6 +9,7 @@ from PIL import Image
 import config
 from calc import calc_price_tax_in, calc_sum_price
 from gui_last_page import show_last_page
+from modify_from_history import write_modified_result, write_item_fixes
 from resize_image import resize_img
 
 
@@ -299,17 +300,6 @@ class OperationFrame():
                 csv.writer(file).writerow(row)
 
 
-    def write_item_fixes(self):
-        item_before = self.ocr_result['item']
-        item_after = [s.get() for s in self.item_places['item']]
-        item_fix = [(before, after) for before, after in zip(item_before, item_after) if before != after]
-        csv_path = os.path.join(os.path.dirname(__file__), '../csv/learning_file/item_ocr_fix.csv')
-        with open(csv_path, mode='r+') as file:
-            reader = [tuple(row) for row in csv.reader(file)]
-            add_row = [list(s) for s in list(set(item_fix) - set(reader))]
-            csv.writer(file, quoting=csv.QUOTE_NONE, escapechar='\\').writerows(add_row)
-
-
     def next_receipt(self):
         self.gui.change_page()
         next_receipt_no = self.receipt_no + 1
@@ -320,8 +310,9 @@ class OperationFrame():
 
     def show_button_next_receipt(self):
         def next_step():
-            self.write_modified_result()
-            self.write_item_fixes()
+            #self.write_modified_result()
+            write_modified_result(self.info_places, self.item_places)
+            write_item_fixes(self.ocr_result['item'], self.item_places['item'])
             if self.receipt_no + 1 < self.num_receipts:
                 self.next_receipt()
             else:

--- a/household_accounts/gui_each_receipt.py
+++ b/household_accounts/gui_each_receipt.py
@@ -9,7 +9,7 @@ from PIL import Image
 import config
 from calc import calc_price_tax_in, calc_sum_price
 from gui_last_page import show_last_page
-from modify_from_history import write_modified_result, write_item_fixes
+from write_csv import write_modified_result, write_item_fixes
 from resize_image import resize_img
 
 
@@ -283,23 +283,6 @@ class OperationFrame():
         self.show_button_next_receipt()
 
 
-    def write_modified_result(self):
-        date = self.info_places['date'].get()
-        shop = self.info_places['shop'].get()
-        today = datetime.datetime.now().strftime('%Y%m%d')
-        csv_path = os.path.join(os.path.dirname(__file__), '../csv/{}.csv'.format(today))
-        with open(csv_path, mode='a') as file:
-            required = self.item_places['required']
-            index_required = [i for i, r in enumerate(required) if r.get()==1]
-            for i in index_required:
-                item = self.item_places['item'][i].get()
-                price = self.item_places['price'][i].get()
-                major_category = self.item_places['major_category'][i].get()
-                medium_category = self.item_places['medium_category'][i].get()
-                row = [date, item, price, major_category, medium_category, shop]
-                csv.writer(file).writerow(row)
-
-
     def next_receipt(self):
         self.gui.change_page()
         next_receipt_no = self.receipt_no + 1
@@ -310,7 +293,6 @@ class OperationFrame():
 
     def show_button_next_receipt(self):
         def next_step():
-            #self.write_modified_result()
             write_modified_result(self.info_places, self.item_places)
             write_item_fixes(self.ocr_result['item'], self.item_places['item'])
             if self.receipt_no + 1 < self.num_receipts:

--- a/household_accounts/ocr.py
+++ b/household_accounts/ocr.py
@@ -140,7 +140,6 @@ def translate_item_fixes(item):
         before = [s[0] for s in reader]
         after = [s[1] for s in reader]
     item_fix = [after[before.index(s)] if s in before else s for s in item]
-    print(item_fix)
     return item_fix
 
         

--- a/household_accounts/ocr.py
+++ b/household_accounts/ocr.py
@@ -1,3 +1,5 @@
+import csv
+import os
 import pyocr
 import pyocr.builders
 import re
@@ -131,10 +133,21 @@ class OcrReceipt:
                 del self.discount[index]
 
 
-def summing_up_ocr_results(ocr):
+def translate_item_fixes(item):
+    csv_path = os.path.join(os.path.dirname(__file__), '../csv/learning_file/item_ocr_fix.csv')
+    with open(csv_path, mode='r') as file:
+        reader = [row for row in csv.reader(file)]
+        before = [s[0] for s in reader]
+        after = [s[1] for s in reader]
+    item_fix = [after[before.index(s)] if s in before else s for s in item]
+    print(item_fix)
+    return item_fix
+
+        
+def summing_up_ocr_results(ocr, item_fix):
     result = {}
     result['payment_date'] = ocr.payment_date
-    result['item'] = ocr.item
+    result['item'] = item_fix
     result['price'] = ocr.price
     result['reduced_tax_rate_flg'] = ocr.reduced_tax_rate_flg
     result['tax_excluded_flg'] = ocr.tax_excluded
@@ -154,7 +167,8 @@ def main():
     ocr_results = {}
     for i, input_file in enumerate(input_path_list):
         ocr = OcrReceipt(input_file)
-        ocr_results[input_file] = summing_up_ocr_results(ocr)
+        item_fix = translate_item_fixes(ocr.item)
+        ocr_results[input_file] = summing_up_ocr_results(ocr, item_fix)
         indicate_processing_status(i, len(input_path_list))
     return ocr_results
 

--- a/household_accounts/write_csv.py
+++ b/household_accounts/write_csv.py
@@ -1,0 +1,31 @@
+import csv
+import datetime
+import os
+
+
+def write_modified_result(info_places, item_places):
+    date = info_places['date'].get()
+    shop = info_places['shop'].get()
+    today = datetime.datetime.now().strftime('%Y%m%d')
+    csv_path = os.path.join(os.path.dirname(__file__), '../csv/{}.csv'.format(today))
+    with open(csv_path, mode='a') as file:
+        required = item_places['required']
+        index_required = [i for i, r in enumerate(required) if r.get()==1]
+        for i in index_required:
+            item = item_places['item'][i].get()
+            price = item_places['price'][i].get()
+            major_category = item_places['major_category'][i].get()
+            medium_category = item_places['medium_category'][i].get()
+            row = [date, item, price, major_category, medium_category, shop]
+            csv.writer(file).writerow(row)
+
+
+def write_item_fixes(item_ocr, item_places):
+    item_before = item_ocr
+    item_after = [s.get() for s in item_places]
+    item_fix = [(before, after) for before, after in zip(item_before, item_after) if before != after]
+    csv_path = os.path.join(os.path.dirname(__file__), '../csv/learning_file/item_ocr_fix.csv')
+    with open(csv_path, mode='r+') as file:
+        reader = [tuple(row) for row in csv.reader(file)]
+        add_row = [list(s) for s in list(set(item_fix) - set(reader))]
+        csv.writer(file, quoting=csv.QUOTE_NONE, escapechar='\\').writerows(add_row)


### PR DESCRIPTION
GUI画面で修正した品目名を履歴として残しておいて、同じOCR結果を得た時にはGUI画面に修正した品目名を予め表示できるようにする。

例
1　OCRで「ギュウニュ 1L」と読み取り
2　GUI画面で「牛乳」と手動で修正（修正前後の内容を保存しておく）
3　次のレシートで再び「ギュウニュ 1L」と読み取ったときには、結果を自動修正
4　GUI画面で「牛乳」と表示する

とりあえずこのプルリクでは完全一致したときのみ自動修正するようにする
（読み取り結果が「ギュウニュ 1L」と微妙に違うときは「牛乳」に自動変換しない）