### PR TITLE
中間imgファイルを消す

### DIFF
--- a/household_accounts/edit_image.py
+++ b/household_accounts/edit_image.py
@@ -1,3 +1,4 @@
+import glob
 import os
 from PIL import Image
 
@@ -16,6 +17,13 @@ def resize_img(file_path, resize_width, resize_height):
     dirname, basename = os.path.split(file_path)
     filename, extension = os.path.splitext(basename)
     resize_file_path = dirname + '/resize/' + filename + '_resize' + extension
-    #resize_file_path = file_path[:-4] + '_resize' + extension
     resize_img.save(resize_file_path)
     return resize_file_path
+
+
+def delete_img(img_path):
+    img_delete_path = os.path.join(os.path.dirname(__file__), img_path)
+    img_delete_path_list = glob.glob(img_delete_path, recursive=True)
+    for p in img_delete_path_list:
+        if os.path.isfile(p):
+            os.remove(p)

--- a/household_accounts/gui_each_receipt.py
+++ b/household_accounts/gui_each_receipt.py
@@ -11,7 +11,7 @@ from calc import calc_price_tax_in, calc_sum_price
 from gui_last_page import show_last_page
 from ocr import determine_category, read_category
 from write_csv import write_modified_result, write_item_fixes, write_category_fixes
-from resize_image import resize_img
+from edit_image import resize_img
 
 
 class DivideScreen():

--- a/household_accounts/gui_last_page.py
+++ b/household_accounts/gui_last_page.py
@@ -1,12 +1,28 @@
 import datetime
+import glob
+import os
 import tkinter as tk
 
 def show_last_page(gui):
+    def show_message():
+        today = datetime.datetime.now().strftime('%Y%m%d')
+        csv_path = 'csv/{}.csv'.format(today)
+        message = '終了しました。読み取ったデータは{}に保存されています。'.format(csv_path)
+        message_label = tk.Label(gui.next_page, text=message)
+        message_label.pack(anchor='center')
+    
+    def show_close_button():
+        def close_button_function():
+            img_delete_path = os.path.join(os.path.dirname(__file__), '../img/interim/**/*.png')
+            img_delete_path_list = glob.glob(img_delete_path, recursive=True)
+            for p in img_delete_path_list:
+                if os.path.isfile(p):
+                    os.remove(p)
+            gui.destroy()
+    
+        close_button = tk.Button(gui.next_page, text='閉じる', command=close_button_function)
+        close_button.pack(anchor='s', ipadx=100, ipady=15)
+
     gui.change_page()
-    today = datetime.datetime.now().strftime('%Y%m%d')
-    csv_path = 'csv/{}.csv'.format(today)
-    message = '終了しました。読み取ったデータは{}に保存されています。'.format(csv_path)
-    message_label = tk.Label(gui.next_page, text=message)
-    message_label.pack(anchor='center')
-    close_button = tk.Button(gui.next_page, text='閉じる', command=gui.destroy)
-    close_button.pack(anchor='s', ipadx=100, ipady=15)
+    show_message()
+    show_close_button()

--- a/household_accounts/gui_last_page.py
+++ b/household_accounts/gui_last_page.py
@@ -1,7 +1,8 @@
 import datetime
-import glob
-import os
 import tkinter as tk
+
+from edit_image import delete_img
+
 
 def show_last_page(gui):
     def show_message():
@@ -13,11 +14,7 @@ def show_last_page(gui):
     
     def show_close_button():
         def close_button_function():
-            img_delete_path = os.path.join(os.path.dirname(__file__), '../img/interim/**/*.png')
-            img_delete_path_list = glob.glob(img_delete_path, recursive=True)
-            for p in img_delete_path_list:
-                if os.path.isfile(p):
-                    os.remove(p)
+            delete_img('../img/interim/**/*.png')
             gui.destroy()
     
         close_button = tk.Button(gui.next_page, text='閉じる', command=close_button_function)

--- a/household_accounts/gui_show_receipt_contours.py
+++ b/household_accounts/gui_show_receipt_contours.py
@@ -3,7 +3,7 @@ import tkinter as tk
 import config
 import gui_each_receipt
 from get_file_path_list import get_input_path_list
-from resize_image import resize_img
+from edit_image import resize_img
 
 
 class MakeFirstPage():


### PR DESCRIPTION
GUI画面閉じるタイミングで、GUI画面への表示用に作成したimgファイルを消去する

※　元のレシート画像を1枚しか置いていなかったときには気づいていなかったが、中間ファイルをそのまま残して新たなレシート画像を読み込むと中間ファイル全てを全て処理してしまう。これは処理の内容がそうなっている（中間ファイルを置いているディレクトリ内の特定の名称のファイル全てを処理対象とする）ことが原因。
処理内容を変えることも可能だが、いずれにしても中間ファイルは読み取り後は不要と考えること、中間ファイルの数が多いことから、中間ファイルを都度（元のレシート画像を1枚処理するたびに）消していくようにする。