### PR TITLE
pyocrのbuilderを LineBoxBuilder から TextBuilder に変更

### DIFF
--- a/household_accounts/ocr.py
+++ b/household_accounts/ocr.py
@@ -41,11 +41,10 @@ class OcrReceipt:
         receipt_ocr = tool.image_to_string(
             Image.open(input_file),
             lang='jpn',
-            builder=pyocr.builders.LineBoxBuilder(tesseract_layout=4)
+            builder=pyocr.builders.TextBuilder(tesseract_layout=4)
             )
         
-        receipt_content = list(map(lambda x: x.content, receipt_ocr))
-        receipt_content = [i for i in receipt_content if i != '']
+        receipt_content = receipt_ocr.split("\n")
         content_en = []
         content = []
         for row in receipt_content:


### PR DESCRIPTION
https://github.com/yrarchi/household_accounts/issues/28#issuecomment-1114231212 の対応を行う

> ### tesseractのエラーへの対応
> https://github.com/yrarchi/household_accounts/issues/28#issuecomment-1114224354 で試して、エラーの出なかった file_ext がtxt なのはTextBuilder のみ
元々使用していた LineBoxBuilder は行単位でOCRして文字位置も合わせて返すが、文字位置はその後使用していない。TextBuilder で返ってくるOCR結果の文字列は改行文字を含むことを確認したので、改行文字でsplitするようにすれば、今回の用途を満たす。
TextBuilderに切り替えることにする。