### PR TITLE
行数を増やすボタンを追加

### DIFF
--- a/household_accounts/gui_each_receipt.py
+++ b/household_accounts/gui_each_receipt.py
@@ -153,6 +153,7 @@ class ItemFrame:
         self.num_item = len(self.ocr_result["item"])
         self.show_item_column()
         self.item_places = self.insert_ocr_value()
+        self.show_button_add_row()
         self.show_price_tax_in()
         self.show_button_recalculation()
 
@@ -324,6 +325,25 @@ class ItemFrame:
             column=4,
             rowspan=2,
             columnspan=2,
+            sticky=tk.E,
+            ipadx=20,
+        )
+
+    def add_row(self):
+        places = self.place_items(self.num_item + 1)
+        for name in self.item_names:
+            self.item_places[name].append(places[name])
+        self.num_item += 1
+        self.show_price_tax_in()
+        self.show_button_recalculation()
+
+    def show_button_add_row(self):
+        add_row_button = ttk.Button(self.frame, text="行を増やす", command=self.add_row)
+        add_row_button.grid(
+            row=self.num_item + 8,
+            column=1,
+            rowspan=1,
+            columnspan=1,
             sticky=tk.E,
             ipadx=20,
         )

--- a/household_accounts/gui_each_receipt.py
+++ b/household_accounts/gui_each_receipt.py
@@ -307,9 +307,11 @@ class ItemFrame:
             sum_price_str_labal.grid(
                 row=self.num_item + 2, column=3, columnspan=2, sticky=tk.E
             )
-
             price_sum_labal = tk.Label(self.frame, text=sum_price)
             price_sum_labal.grid(row=self.num_item + 2, column=5, sticky=tk.E, ipadx=20)
+
+            self.sum_price_str_labal = sum_price_str_labal
+            self.price_sum_labal = price_sum_labal
 
         price_tax_in_list, sum_price = self.calc_price_tax_in()
         show_item_prices_tax_in(price_tax_in_list)
@@ -319,8 +321,8 @@ class ItemFrame:
         def recalc():
             self.show_price_tax_in()
 
-        calc_button = ttk.Button(self.frame, text="再計算", command=recalc)
-        calc_button.grid(
+        button_recalculation = ttk.Button(self.frame, text="再計算", command=recalc)
+        button_recalculation.grid(
             row=self.num_item + 3,
             column=4,
             rowspan=2,
@@ -328,17 +330,25 @@ class ItemFrame:
             sticky=tk.E,
             ipadx=20,
         )
+        self.button_recalculation = button_recalculation
 
     def add_row(self):
         places = self.place_items(self.num_item + 1)
         for name in self.item_names:
             self.item_places[name].append(places[name])
         self.num_item += 1
+        print("add_row", self.num_item)
+
+        self.sum_price_str_labal.destroy()
+        self.price_sum_labal.destroy()
         self.show_price_tax_in()
+
+        self.button_recalculation.destroy()
         self.show_button_recalculation()
 
     def show_button_add_row(self):
         add_row_button = ttk.Button(self.frame, text="行を増やす", command=self.add_row)
+        print("show_button", self.num_item)
         add_row_button.grid(
             row=self.num_item + 8,
             column=1,

--- a/household_accounts/gui_each_receipt.py
+++ b/household_accounts/gui_each_receipt.py
@@ -170,9 +170,7 @@ class ItemFrame:
         places["price"] = tk.Entry(self.frame, width=6, justify=tk.RIGHT)
         places["discount"] = tk.Entry(self.frame, width=6, justify=tk.RIGHT)
 
-        places["reduced_tax_rate"] = tk.IntVar(
-            value=self.ocr_result["reduced_tax_rate_flg"][row - 1]
-        )
+        places["reduced_tax_rate"] = tk.IntVar()
         reduced_tax_rate_flg = ttk.Checkbutton(
             self.frame, variable=places["reduced_tax_rate"]
         )
@@ -206,6 +204,7 @@ class ItemFrame:
             "medium_category",
         ]:
             places[column].insert(tk.END, self.ocr_result[column][row])
+        places["reduced_tax_rate"].set(self.ocr_result["reduced_tax_rate_flg"][row])
 
     def validate_item(self, places):
         def item_validate(value):

--- a/household_accounts/gui_each_receipt.py
+++ b/household_accounts/gui_each_receipt.py
@@ -350,7 +350,7 @@ class ItemFrame:
         add_row_button = ttk.Button(self.frame, text="行を増やす", command=self.add_row)
         print("show_button", self.num_item)
         add_row_button.grid(
-            row=self.num_item + 8,
+            row=self.num_item + 8,  # 最大8行追加できる
             column=1,
             rowspan=1,
             columnspan=1,

--- a/household_accounts/gui_each_receipt.py
+++ b/household_accounts/gui_each_receipt.py
@@ -337,7 +337,6 @@ class ItemFrame:
         for name in self.item_names:
             self.item_places[name].append(places[name])
         self.num_item += 1
-        print("add_row", self.num_item)
 
         self.sum_price_str_labal.destroy()
         self.price_sum_labal.destroy()
@@ -348,7 +347,6 @@ class ItemFrame:
 
     def show_button_add_row(self):
         add_row_button = ttk.Button(self.frame, text="行を増やす", command=self.add_row)
-        print("show_button", self.num_item)
         add_row_button.grid(
             row=self.num_item + 8,  # 最大8行追加できる
             column=1,


### PR DESCRIPTION
OCRで適切に読み取れていない場合、レシートに品目が3件あるのに2件しか画面に表示されない場合がある。
そういった際に行を追加することができるボタンを追加する。