### PR TITLE
runnerのosをlinuxにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.11'
+          python-version: '3.9'
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
 jobs:
   lint_and_format:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.7.8'
+          python-version: '3.11'
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python -


### PR DESCRIPTION
使用しているGithub Actionsの実行が完了しない。
https://github.com/yrarchi/household_accounts/pull/41

runnerのOSを macos-10.15 にしていたが、以下を確認するとdeprecatedになっていた。
https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/
macを使用する必要もないので、今回 linux に変更する。